### PR TITLE
Updates to work with SwiftPhoenixClient(v3.0.0)'s breaking release

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,8 +13,8 @@ let package = Package(
             targets: ["AbsintheSocketTransport"]),
     ],
     dependencies: [
-      .package(url: "https://github.com/davidstump/SwiftPhoenixClient.git", from: "2.1.1"),
-      .package(name: "Apollo", url: "https://github.com/apollographql/apollo-ios.git", .upToNextMinor(from: "0.48.0")),
+      .package(url: "https://github.com/davidstump/SwiftPhoenixClient.git", from: "3.0.0"),
+      .package(name: "Apollo", url: "https://github.com/apollographql/apollo-ios.git", .upToNextMinor(from: "0.50.0")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,16 @@ let transport = AbsintheSocketTransport(endpoint, params: ["token": token])
 let client = ApolloClient(networkTransport: transport, store: ApolloStore.init())
 ```
 
-Although untested, this transport might also work as part of a `SplitNetworkTransport`.
+This transport also works as part of a `SplitNetworkTransport`, which could be configured such as:
+
+```swift
+let normalTransport: RequestChainNetworkTransport = ...  // Your normal http transport
+let absintheSocketTransport = AbsintheSocketTransport(endpoint, params: ["token": token])
+let splitTransport = SplitNetworkTransport(
+  uploadingNetworkTransport: normalTransport,
+  webSocketNetworkTransport: absintheSocketTransport
+)
+```
 
 For debugging purposes, you can enable a printout of all socket messages (including keepalives):
 

--- a/Sources/AbsintheSocketTransport/AbsintheMessage.swift
+++ b/Sources/AbsintheSocketTransport/AbsintheMessage.swift
@@ -57,7 +57,7 @@ enum AbsintheMessage {
     operation: Operation,
     message: Message
   ) -> Result<GraphQLResult<Operation.Data>, Error> {
-    guard let response = message.payload["response"] as? [String: Any]
+    guard let response = message.payload as? [String: Any]
     else {
       return .failure(AbsintheError(kind: .parseError, payload: message.payload))
     }
@@ -76,16 +76,11 @@ enum AbsintheMessage {
    * - returns: Result with the subscription ID
    */
   static func parseSubscriptionStart(_ message: Message) -> Result<String, Error> {
-    guard
-      message.payload["status"] as? String == "ok"
-    else {
+    guard message.status == "ok" else {
       return .failure(AbsintheError(kind: .queryError, payload: message.payload))
     }
 
-    guard
-      let response = message.payload["response"] as? [String: Any],
-      let id = response["subscriptionId"] as? String
-    else {
+    guard let id = message.payload["subscriptionId"] as? String else {
       return .failure(AbsintheError(kind: .parseError, payload: message.payload))
     }
 


### PR DESCRIPTION
With this branch aimed at bringing `SwiftPhoenixClient` and `Apollo` up to their latest versions respectively, the code
changed is successfully using the most recent `Apollo` library, and reflects `SwiftPhoenixClient`'s most recent `3.0.0` breaking release, which was in order to properly match the `phoenix.js` library, which in summary:
1. The client now uses the `JSON V2 Serializer` by default (Phoenix 1.3+)
2. `message.payload.response` is now automatically unwrapped and returned as `message.payload` for `phx_reply` events.

I also have been using the code base as part of a `SplitNetworkTransport` with no problems, thus also updated the `README`.